### PR TITLE
Fix Zenodo DOI badge: use concept-DOI URL instead of auto-resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Jupyter Book](https://img.shields.io/badge/jupyter--book-live-blue?logo=jupyter)](https://ncar.github.io/gdex-examples/)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue?logo=python)](https://www.python.org/)
-[![DOI](https://zenodo.org/badge/1041581979.svg)](https://zenodo.org/badge/latestdoi/1041581979)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20330479.svg)](https://doi.org/10.5281/zenodo.20330479)
 
 A collection of Jupyter notebooks demonstrating geoscientific workflows that
 use data from NCAR's [Geoscience Data Exchange (GDEX)](https://gdex.ucar.edu/),

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -5,7 +5,7 @@ date: 2026-1-20
 
 # Introduction
 
-[![DOI](https://zenodo.org/badge/1041581979.svg)](https://zenodo.org/badge/latestdoi/1041581979)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20330479.svg)](https://doi.org/10.5281/zenodo.20330479)
 
 Welcome to **NCAR GDEX Examples** — a collection of Jupyter notebooks that demonstrate geoscientific workflows using data from NCAR's [Geoscience Data Exchange (GDEX)](https://gdex.ucar.edu/). Each example shows how to access a specific GDEX dataset and use it for analysis or visualization, with computations performed on NCAR's HPC resources (Casper / Derecho).
 


### PR DESCRIPTION
The auto-resolving badge URL https://zenodo.org/badge/{repo_id}.svg returns an HTTP 302 redirect to the concrete DOI badge SVG. GitHub's camo image proxy and MyST's static-asset rendering do not follow redirects for <img> tags, so the badge displayed as broken on both the README on github.com and the rendered Jupyter Book site.

Switch to the concept-DOI form (10.5281/zenodo.20330479), which returns the SVG directly (HTTP 200, image/svg+xml) and still resolves to the latest version on click. This URL is stable across all future releases — no badge edits needed when v2026.06 etc. ship.