### PR TITLE
Add Urban Heat MiniCubes notebook to ToC; add YAML frontmatter

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -30,6 +30,7 @@ project:
         - file: notebooks/hadisst_elnino.ipynb
         - file: notebooks/eol_radar_precip.ipynb
         - file: notebooks/raf_socrates.ipynb
+        - file: notebooks/urban_heat_minicubes_analysis.ipynb
     - title: Analysis
       children:
         - file: docs/analysis.md

--- a/notebooks/urban_heat_minicubes_analysis.ipynb
+++ b/notebooks/urban_heat_minicubes_analysis.ipynb
@@ -4,10 +4,7 @@
    "cell_type": "markdown",
    "id": "5febf986-9161-4f11-9af1-9ba0befa795e",
    "metadata": {},
-   "source": [
-    "# Access Urban Heat MiniCubes through the NCAR GDEX\n",
-    "Author: Jonathan Starfeldt"
-   ]
+   "source": "---\ntitle: Access Urban Heat MiniCubes through the NCAR GDEX\nauthor: Jonathan Starfeldt\ndate: 2026-07-08\n---"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
- Wire notebooks/urban_heat_minicubes_analysis.ipynb into myst.yml under Observations so it renders in the book
- Convert the title cell to MyST frontmatter (title/author/date) so the page title and author render consistently with the other notebooks